### PR TITLE
Added created_by field to tables

### DIFF
--- a/VirtueVerse/app/Http/Controllers/BookController.php
+++ b/VirtueVerse/app/Http/Controllers/BookController.php
@@ -117,13 +117,19 @@ class BookController extends Controller
         $request->validate([
             'query' => 'required|string',
         ]);
-    
+        
+        Log::info("Search query:");
+        Log::info($request->input('query'));
         $query = $request->input('query');
 
+        Log::info("Search query:");
+        Log::info("https://openlibrary.org/search.json?q=$query&fields=title,first_publish_year,author_name,edition_key&limit=10&mode=everything");
         $response = Http::withOptions(['verify' => false])->get("https://openlibrary.org/search.json?q=$query&fields=title,first_publish_year,author_name,edition_key&limit=10&mode=everything");
+        
 
         if ($response->successful()) 
         {
+            Log::info("Query successful");
             $searchResults = $response->json();
             return response()->json(['results' => $searchResults]);
         }

--- a/VirtueVerse/app/Http/Middleware/CheckUserRole.php
+++ b/VirtueVerse/app/Http/Middleware/CheckUserRole.php
@@ -16,8 +16,6 @@ class CheckUserRole
      */
     public function handle(Request $request, Closure $next, ...$roles): Response
     {
-        Log::info($roles);
-        Log::info(auth()->user()->userRole->name);
 
         if (in_array(auth()->user()->userRole->name, $roles)) {
             return $next($request);

--- a/VirtueVerse/app/Models/Author.php
+++ b/VirtueVerse/app/Models/Author.php
@@ -4,6 +4,9 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use App\Models\Scopes\CreatedByScope;
+use Illuminate\Support\Facades\Log;
+use App\Observers\AuthorObserver;
 
 class Author extends Model
 {
@@ -16,6 +19,13 @@ class Author extends Model
         'biography', 
         'open_library_key' // Add open_library_key for author key, similar to Book
     ];
+
+    protected static function boot()
+    {
+        parent::boot();
+    
+        Author::observe(AuthorObserver::class);
+    }
 
     public function books()
     {

--- a/VirtueVerse/app/Models/Book.php
+++ b/VirtueVerse/app/Models/Book.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Observers\BookObserver;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
@@ -19,6 +20,13 @@ class Book extends Model
         'editions_key',
         'author_id'
     ];
+
+    protected static function boot()
+    {
+        parent::boot();
+    
+        Book::observe(BookObserver::class);
+    }
 
     public function author()
     {

--- a/VirtueVerse/app/Models/BookEdition.php
+++ b/VirtueVerse/app/Models/BookEdition.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Observers\BookEditionObserver;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
@@ -20,6 +21,13 @@ class BookEdition extends Model
         'editions_key',
         'pages',
     ];
+
+    protected static function boot()
+    {
+        parent::boot();
+    
+        BookEdition::observe(BookEditionObserver::class);
+    }
 
     public function book()
     {

--- a/VirtueVerse/app/Observers/AuthorObserver.php
+++ b/VirtueVerse/app/Observers/AuthorObserver.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Observers;
+use App\Models\Author;
+
+class AuthorObserver
+{
+    public function creating(Author $author)
+    {
+        $author->created_by = auth()->id();
+    }
+}

--- a/VirtueVerse/app/Observers/BookEditionObserver.php
+++ b/VirtueVerse/app/Observers/BookEditionObserver.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Observers;
+use App\Models\BookEdition;
+
+class BookEditionObserver
+{
+    public function creating(BookEdition $bookEdition)
+    {
+        $bookEdition->created_by = auth()->id();
+    }
+}

--- a/VirtueVerse/app/Observers/BookObserver.php
+++ b/VirtueVerse/app/Observers/BookObserver.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Observers;
+use App\Models\Book;
+
+class BookObserver
+{
+    public function creating(Book $book)
+    {
+        $book->created_by = auth()->id();
+    }
+}

--- a/VirtueVerse/app/Providers/EventServiceProvider.php
+++ b/VirtueVerse/app/Providers/EventServiceProvider.php
@@ -2,10 +2,17 @@
 
 namespace App\Providers;
 
+use App\Models\Book;
+use App\Models\BookEdition;
+use App\Observers\BookEditionObserver;
+use App\Observers\BookObserver;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Event;
+use App\Models\Author;
+use App\Observers\AuthorObserver;
+use Illuminate\Database\Eloquent\Events\Creating;
 
 class EventServiceProvider extends ServiceProvider
 {
@@ -17,6 +24,15 @@ class EventServiceProvider extends ServiceProvider
     protected $listen = [
         Registered::class => [
             SendEmailVerificationNotification::class,
+        ],
+        AuthorCreating::class => [
+            AuthorObserver::class,
+        ],
+        BookEditionCreating::class => [
+            BookEditionObserver::class,
+        ],
+        BookCreating::class => [
+            BookObserver::class,
         ],
     ];
 

--- a/VirtueVerse/database/migrations/2023_10_18_074220_add_created_by_authors.php
+++ b/VirtueVerse/database/migrations/2023_10_18_074220_add_created_by_authors.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('authors', function (Blueprint $table) {
+            $table->unsignedBigInteger('created_by')->nullable();
+            $table->foreign('created_by')->references('id')->on('users');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('authors', function (Blueprint $table) {
+            $table->dropForeign(['created_by']);
+            $table->dropColumn('created_by');
+        });
+    }
+};

--- a/VirtueVerse/database/migrations/2023_10_18_102433_add_created_by_book_editions.php
+++ b/VirtueVerse/database/migrations/2023_10_18_102433_add_created_by_book_editions.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('book_editions', function (Blueprint $table) {
+            $table->unsignedBigInteger('created_by')->nullable();
+            $table->foreign('created_by')->references('id')->on('users');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('book_editions', function (Blueprint $table) {
+            $table->dropForeign(['created_by']);
+            $table->dropColumn('created_by');
+        });
+    }
+};

--- a/VirtueVerse/database/migrations/2023_10_18_102438_add_created_by_books.php
+++ b/VirtueVerse/database/migrations/2023_10_18_102438_add_created_by_books.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('books', function (Blueprint $table) {
+            $table->unsignedBigInteger('created_by')->nullable();
+            $table->foreign('created_by')->references('id')->on('users');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('books', function (Blueprint $table) {
+            $table->unsignedBigInteger('created_by')->nullable();
+            $table->foreign('created_by')->references('id')->on('users');
+        });
+    }
+};

--- a/VirtueVerse/database/migrations/2023_10_18_114023_make_isbn_nullable.php
+++ b/VirtueVerse/database/migrations/2023_10_18_114023_make_isbn_nullable.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('book_editions', function (Blueprint $table) {
+            $table->string('isbn')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        //
+    }
+};

--- a/VirtueVerse/resources/js/books/book.js
+++ b/VirtueVerse/resources/js/books/book.js
@@ -88,6 +88,7 @@ async function displaySearchResults(results) {
 async function searchBooks(query) {
     try {
         query = spaceEncoder(query) // Replace space with valid character
+        debugger;
         const response = await axios.get(`/book/search?query=${query}`);
 
         const results = response.data.results.docs;

--- a/VirtueVerse/resources/views/books/create.blade.php
+++ b/VirtueVerse/resources/views/books/create.blade.php
@@ -10,50 +10,48 @@
 
 <h1 class="text-3xl font-bold underline">Hello book</h1>
 
-<div class="max-w-5xl p-4">
-    <div class="mb-4">
-        <input
-            type="text"
-            id="search-query"
-            placeholder="Search for books"
-            class="border rounded py-2 px-3 w-full"
-        >
-        <ul
-            id="search-results"
-            class="absolute left-0 mt-2 w-full bg-white border rounded shadow-md max-h-48 overflow-y-auto z-10"
-        ></ul>
-    </div>
-
-    <!-- Book Creation Form -->
-    <form action="{{ route('book.store') }}" method="POST" class="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4">
-        @csrf
-
-        @if ($errors->any())
-            <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative" role="alert">
-                <ul>
-                    @foreach ($errors->all() as $error)
-                        <li class="list-disc">{{ $error }}</li>
-                    @endforeach
-                </ul>
-            </div>
-        @endif
-        
-        <x-forms.text-input type="text" id="title" label="Title" name="title" placeholder="Title" />
-        <x-forms.combobox-input id="author" name="author" label="Author" :models="$authors" idField="id" valueField="name"></x-forms.combobox-input>
-        <x-forms.text-input type="number" id="publication-year" label="Publication year" name="publication-year" placeholder="Publication year" />
-        <x-forms.textarea id="description" label="Description" name="description" placeholder="Description" />
-
-        <input type="hidden" name="open-library-key" id="open-library-key">
-        <input type="hidden" name="author-id" id="author-id">
-
-        <div class="flex items-center justify-between">
-            <button
-                class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline"
-                type="submit">
-                Create Book
-            </button>
-        </div>
-    </form>
+<div class="mb-4">
+    <input
+        type="text"
+        id="search-query"
+        placeholder="Search for books"
+        class="border rounded py-2 px-3 w-full"
+    >
+    <ul
+        id="search-results"
+        class="absolute left-0 mt-2 w-full bg-white border rounded shadow-md max-h-48 overflow-y-auto z-10"
+    ></ul>
 </div>
+
+<!-- Book Creation Form -->
+<form action="{{ route('book.store') }}" method="POST" class="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4">
+    @csrf
+
+    @if ($errors->any())
+        <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative" role="alert">
+            <ul>
+                @foreach ($errors->all() as $error)
+                    <li class="list-disc">{{ $error }}</li>
+                @endforeach
+            </ul>
+        </div>
+    @endif
+    
+    <x-forms.text-input type="text" id="title" label="Title" name="title" placeholder="Title" />
+    <x-forms.combobox-input id="author" name="author" label="Author" :models="$authors" idField="id" valueField="name"></x-forms.combobox-input>
+    <x-forms.text-input type="number" id="publication-year" label="Publication year" name="publication-year" placeholder="Publication year" />
+    <x-forms.textarea id="description" label="Description" name="description" placeholder="Description" />
+
+    <input type="hidden" name="open-library-key" id="open-library-key">
+    <input type="hidden" name="author-id" id="author-id">
+
+    <div class="flex items-center justify-between">
+        <button
+            class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline"
+            type="submit">
+            Create Book
+        </button>
+    </div>
+</form>
 
 @endsection

--- a/VirtueVerse/routes/web.php
+++ b/VirtueVerse/routes/web.php
@@ -64,13 +64,13 @@ Route::middleware(['auth', 'auth.roles:Admin,Editor,User'])->group(function () {
 // Routes for registration
 require __DIR__.'/auth.php';
 
-// Route::get('book/create', 'BookController@create')->name('book.create');
 Route::get('book/catalogue', [BookController::class, 'catalogue'])->name('book.catalogue');
-Route::get('/book/{id}', [BookController::class, 'show'])->name('book.show');
 Route::get('/book/search', [BookController::class, 'search'])->name('book.search');
 Route::get('book/searchStoredBooks', [BookController::class, 'searchStoredBooks'])->name('book.searchStoredBooks');
 Route::get('book/getBookInfo', [BookController::class, 'getBookInfo'])->name('book.getBookInfo');
 Route::get('book/getBook', [BookController::class, 'getBook'])->name('book.getBook');
+Route::get('/book/{id}', [BookController::class, 'show'])->name('book.show');
+Route::get('book/create', [BookController::class, 'create'])->name('book.create');
 
 Route::get('/author/search', [AuthorController::class, 'search'])->name('author.search');
 Route::get('author/getAuthorInfo', [AuthorController::class, 'getAuthorInfo'])->name('author.getAuthorInfo');


### PR DESCRIPTION
Changelog
- Added created_by fields to tables when creating a record
- Added Observers for tables
- Fixed routes for create pages
- Minor styling fixes
- Made ISBN number nullable

Description
Added created_by fields to the author, book and book edition tables, so that it is possible to track which user created which record. Through this, extra authorization can be added. 

This was done through Observer functionality, that automatically populates some of the table methods. This functionality has been choosen instead of just populating in the store() method, because future automatically populated fields might be added later, together with other functionality that should be automatically performed when storing or updating. 

Documentation
None