### PR TITLE
Finished tweaks to book edition catalogue

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,17 @@ https://openlibrary.org/search/authors.json?q=C.S.Lewis&limit=10
 #### Description
 The book table serves as the base of this application. With the use of this application, users can create new books and have the possibility to create corresponding book editions. Books can both be created with manual input and through the Open Library API. Upon using the Open Library API to search through books and adding them, additional Open Library information is stored for easy creation of corresponding book editions.
 
+#### Catalogue
+Through the book catalogue, users have the ability to quickly look through book information. Through filtering and text search, you can easily find your desired book.
+
+### Book editions
+
+#### Description
+To make it possible to store different types of editions / publications of a single book, the 'book editions' table is included in this project. This makes it easier for a user to start a study trajectory for his owned book. One book can have multiple different kinds of book editions, with different ISBN numbers, languages etc.
+
+#### Catalogue
+Like the book table, the book editions table also includes a catalogue in the functionality. This makes it easier for users to find their desired edition to start a study trajectory.
+
 ### User accounts
 
 #### Description

--- a/VirtueVerse/app/Http/Controllers/AuthorController.php
+++ b/VirtueVerse/app/Http/Controllers/AuthorController.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use App\ViewModels\AuthorResultViewModel;
+use App\ViewModels\FilterValueViewModel;
 use App\Models\Author;
 use Carbon\Carbon;
 
@@ -124,5 +125,15 @@ class AuthorController extends Controller
             Log::error('API request failed: ' . json_encode($errorDetails));
             return response()->json(['error' => "API request failed."], 500);
         }
+    }
+
+    public function getAuthorFilterValues(Request $request) {
+        $authors = Author::whereHas('books.editions')->get();
+
+        $authorFilterValues = $authors->map(function ($author) {
+            return new FilterValueViewModel($author->id, $author->name);
+        });
+
+        return response()->json(['authorFilterValues' => $authorFilterValues]);
     }
 }

--- a/VirtueVerse/app/Http/Controllers/BookController.php
+++ b/VirtueVerse/app/Http/Controllers/BookController.php
@@ -7,6 +7,7 @@ use App\Models\Author;
 use App\Http\Controllers\Controller;
 use App\ViewModels\BookEditionResultViewModel;
 use App\ViewModels\BookResultViewModel;
+use App\ViewModels\FilterValueViewModel;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
@@ -188,7 +189,7 @@ class BookController extends Controller
         $query = $request->input('query');
     
         $queryResults = Book::with('author')
-            ->where('title', 'like', "%$query%")
+            ->where('title', 'ilike', "%$query%")
             ->take(10)
             ->get();
 
@@ -247,5 +248,15 @@ class BookController extends Controller
             Log::error('API request failed: ' . json_encode($errorDetails));
             return response()->json(['error' => "API request failed."], 500);
         }
+    }
+
+    public function getBookFilterValues(Request $request) {
+        $books = Book::whereHas('editions')->get();
+
+        $bookFilterValues = $books->map(function ($book) {
+            return new FilterValueViewModel($book->id, $book->title);
+        });
+
+        return response()->json(['bookFilterValues' => $bookFilterValues]);
     }
 }

--- a/VirtueVerse/app/View/Components/books/BookEditionCard.php
+++ b/VirtueVerse/app/View/Components/books/BookEditionCard.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\View\Components\books;
+
+use Closure;
+use Illuminate\View\Component;
+use Illuminate\Contracts\View\View;
+
+class BookEditionCard extends Component
+{
+    public $bookEdition;
+
+    public function __construct($bookEdition)
+    {
+        $this->bookEdition = $bookEdition;
+    }
+
+    /**
+     * Get the view / contents that represent the component.
+     */
+    public function render(): View|Closure|string
+    {
+        return view('components.books.book-edition-card');
+    }
+}

--- a/VirtueVerse/app/View/Components/data-control/FilterControl.php
+++ b/VirtueVerse/app/View/Components/data-control/FilterControl.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\View\Components\dataControl;
+
+use Closure;
+use Illuminate\View\Component;
+use Illuminate\Contracts\View\View;
+
+class FilterControl extends Component
+{
+    public $name;
+    public $label;
+    public $model;
+
+    public function __construct($name, $label, $model)
+    {
+        $this->name = $name;
+        $this->label = $label;
+        $this->model = $model;
+    }
+
+    /**
+     * Get the view / contents that represent the component.
+     */
+    public function render(): View|Closure|string
+    {
+        return view('components.data-control.filter-control');
+    }
+}

--- a/VirtueVerse/app/View/Components/data-control/InputControl.php
+++ b/VirtueVerse/app/View/Components/data-control/InputControl.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\View\Components\dataControl;
+
+use Closure;
+use Illuminate\View\Component;
+use Illuminate\Contracts\View\View;
+
+class InputControl extends Component
+{
+    public $id;
+    public $model;
+    public $label;
+
+    public function __construct($name, $label, $model)
+    {
+        $this->name = $name;
+        $this->label = $label;
+        $this->model = $model;
+    }
+
+    /**
+     * Get the view / contents that represent the component.
+     */
+    public function render(): View|Closure|string
+    {
+        return view('components.data-control.input-control');
+    }
+}

--- a/VirtueVerse/app/ViewModels/FilterValueViewModel.php
+++ b/VirtueVerse/app/ViewModels/FilterValueViewModel.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\ViewModels;
+
+class FilterValueViewModel
+{
+    public $id;
+    public $value;
+
+    public function __construct($id, $value)
+    {
+        $this->id = $id;
+        $this->value = $value;
+    }
+}

--- a/VirtueVerse/resources/js/bookEditions/bookEditionCatalogue.js
+++ b/VirtueVerse/resources/js/bookEditions/bookEditionCatalogue.js
@@ -1,0 +1,201 @@
+import axios from 'axios';
+import { setFilterSelection, initializeFilter, filters, initializeSearch } from '../components/dataControl/filterControl';
+
+let bookFilterValues;
+let authorFilterValues;
+let templateBookImageSrc;
+let bookFilter = document.getElementById('book-filter');
+let authorFilter = document.getElementById('author-filter');
+let bookEditionInput = document.getElementById("book-edition-search");
+const bookEditionContainer = document.getElementById("book-editions");
+
+document.addEventListener('DOMContentLoaded', async function () {
+    templateBookImageSrc = retrieveTemplateBookImage();
+    bookFilterValues = await getBookFilterValues();
+    authorFilterValues = await getAuthorFilterValues();
+
+    setFilterSelection('book-filter', bookFilterValues);
+    setFilterSelection('author-filter', authorFilterValues);
+
+    initializeFilter('book-filter', getEditionCatalogueData);
+    initializeFilter('author-filter', getEditionCatalogueData);
+    initializeSearch('book-edition-search', getEditionCatalogueData);
+
+    setInitialFilterValues();
+});
+
+function retrieveTemplateBookImage() {
+    const bookEditionCards = document.querySelectorAll('.book-edition-card'); // Use the appropriate selector
+    let retrievedImagePath;
+
+    if (bookEditionCards.length > 0) {
+        const firstBookEditionCard = bookEditionCards[0];
+
+        const firstImage = firstBookEditionCard.querySelector('img');
+
+        if (firstImage) {
+            retrievedImagePath = firstImage.getAttribute('src');
+        }
+    }
+
+    return retrievedImagePath;
+}
+
+async function getBookFilterValues() {
+    try {
+        const response = await axios.get(`/book/getBookFilterValues`);
+
+        const results = response.data.bookFilterValues;
+
+        return results;
+
+    } catch (error) {
+        console.log("Failed sending request")
+        console.log(error.response);
+        throw error; // Rethrow the error to handle it in the calling function
+    }
+}
+
+async function getAuthorFilterValues() {
+    try {
+        const response = await axios.get(`/author/getAuthorFilterValues`);
+
+        const results = response.data.authorFilterValues;
+
+        return results;
+
+    } catch (error) {
+        console.log("Failed sending request")
+        console.log(error.response);
+        throw error; // Rethrow the error to handle it in the calling function
+    }
+}
+
+function setInitialFilterValues() {
+    bookFilter.value = parseInt(document.getElementById("selected-book-id").value);
+}
+
+function setDisplayBook(displayName) {
+    const contentHeader = document.getElementById("book-display-name");
+
+    if(displayName != "") {
+        contentHeader.textContent = "Book edition catalogue: " + displayName;
+    } else {
+        contentHeader.textContent = "Book edition catalogue";
+    }
+}
+
+async function createBookEditionCard(bookEdition) {
+    const { id, title, publication_year, isbn, pages, created_at } = bookEdition;
+
+    const card = document.createElement('a');
+    card.href = `/book-edition/${id}`;
+    card.className = 'block bg-white rounded-lg shadow-md cursor-pointer';
+  
+    const img = document.createElement('img');
+    img.src = templateBookImageSrc;
+    img.alt = title;
+    img.className = 'w-full h-48 object-cover rounded-t-lg';
+    card.appendChild(img);
+  
+    const content = document.createElement('div');
+    content.className = 'p-4';
+  
+    const heading = document.createElement('h2');
+    heading.className = 'text-lg font-semibold mb-2';
+    heading.textContent = title;
+    content.appendChild(heading);
+  
+    const yearParagraph = document.createElement('p');
+    yearParagraph.className = 'text-gray-600';
+    yearParagraph.textContent = `Publicated on: ${publication_year}`;
+    content.appendChild(yearParagraph);
+  
+    if (isbn) {
+      const isbnParagraph = document.createElement('p');
+      isbnParagraph.className = 'text-gray-600';
+      isbnParagraph.textContent = `ISBN number: ${isbn}`;
+      content.appendChild(isbnParagraph);
+    }
+  
+    const pagesParagraph = document.createElement('p');
+    pagesParagraph.className = 'text-gray-600';
+    pagesParagraph.textContent = `Total pages: ${pages}`;
+    content.appendChild(pagesParagraph);
+  
+    card.appendChild(content);
+  
+    const createdDate = new Date(created_at);
+    const dateParagraph = document.createElement('p');
+    dateParagraph.className = 'text-gray-400 text-sm italic';
+    dateParagraph.textContent = `Created on: ${createdDate.toLocaleDateString()}`;
+    content.appendChild(dateParagraph);
+    
+    return card;
+}
+
+async function displayBookEditions(bookEditions) {
+    bookEditionContainer.innerHTML = '';
+    console.log(bookEditions);
+
+    for (var bookEdition of bookEditions) {
+        let bookEditionCard = await createBookEditionCard(bookEdition);
+
+        console.log(bookEditionCard);
+        bookEditionContainer.append(bookEditionCard);
+    }
+}
+
+export async function getSelectedBookInformation(bookId) {
+    try {
+        if(bookId != null) {
+            const response = await axios.get(`/book/getBook?id=${bookId}`);
+        
+            const bookInformation = response.data.book;
+            return bookInformation;
+        }
+    } catch (error) {
+        console.log("Failed sending request")
+        console.log(error.response);
+        throw error; // Rethrow the error to handle it in the calling function
+    }
+}
+
+export async function getEditionCatalogueData(bookEditionFilters) {
+
+    if (!("book-edition" in bookEditionFilters)) {
+        bookEditionFilters['book-edition'] = ""
+    }
+
+    if (!("book" in bookEditionFilters)) {
+        bookEditionFilters['book'] = ""
+    }
+
+    if (!("author" in bookEditionFilters)) {
+        bookEditionFilters['author'] = ""
+    }
+
+    let bookFilter = bookEditionFilters['book'];
+    let authorFilter = bookEditionFilters['author'];
+    let bookEditionFilter = bookEditionFilters['book-edition'];
+
+    console.log(bookEditionFilters);
+
+    try {
+        const response = await axios.get(`/book-edition/retrieveFilteredItems?book=${bookFilter}&author=${authorFilter}&book-edition=${bookEditionFilter}`);
+        
+        const bookEditions = response.data.results;
+        displayBookEditions(bookEditions);
+
+        if (bookFilter != "") {
+            const book = await getSelectedBookInformation(parseInt(bookFilter));
+            setDisplayBook(book.title);
+        } else {
+            setDisplayBook("");
+        }
+    } catch (error) {
+        console.log("Failed sending request")
+        console.log(error.response);
+        throw error; // Rethrow the error to handle it in the calling function
+    }
+}

--- a/VirtueVerse/resources/js/components/dataControl/filterControl.js
+++ b/VirtueVerse/resources/js/components/dataControl/filterControl.js
@@ -1,0 +1,41 @@
+export let filters = {};
+let searchTimeoutId;
+
+export function initializeFilter(componentId, callback) {
+    const filter = document.getElementById(componentId);
+
+    filter.addEventListener('input', async function () {
+        const modelAttribute = filter.getAttribute('model');
+        filters[modelAttribute] = filter.value;
+
+        callback(filters);
+    });
+}
+
+export function initializeSearch(componentId, callback) {
+    const search = document.getElementById(componentId);
+
+    search.addEventListener('input', async function () {
+        const modelAttribute = search.getAttribute('model');
+        filters[modelAttribute] = search.value;
+
+        clearTimeout(searchTimeoutId); // Clear any previous pending requests
+
+        searchTimeoutId = setTimeout(async function() {
+            callback(filters);
+        }, 1000);
+
+    });
+}
+
+export function setFilterSelection(componentId, filterValues) {
+    const filter = document.getElementById(componentId);
+    console.log(filterValues);
+
+    filterValues.forEach(item => {
+        const option = document.createElement('option');
+        option.value = item.id; 
+        option.textContent = item.value;
+        filter.appendChild(option);
+    });
+}

--- a/VirtueVerse/resources/views/app.blade.php
+++ b/VirtueVerse/resources/views/app.blade.php
@@ -9,12 +9,13 @@
     <!-- Navbar -->
     <nav class="bg-zinc-300 p-4">
         <div class="container mx-auto flex flex-wrap justify-between items-center">
-            <div class="w-full lg:w-3/5 mb-4 lg:mb-0">
+            <div class="w-full lg:w-2/5 mb-4 lg:mb-0">
                 <a href="/" class="text-black text-2xl font-bold">VirtueVerse</a>
             </div>
-            <div class="w-full lg:w-2/5 space-x-4 lg:space-x-8 flex items-center lg:justify-end">
+            <div class="w-full lg:w-3/5 space-x-4 lg:space-x-8 flex items-center lg:justify-end">
                 <a href="/" class="text-black hover:underline">Home</a>
                 <a href="/book/catalogue" class="text-black hover:underline">Book Catalogue</a>
+                <a href="/book/catalogue" class="text-black hover:underline">Book Edition Catalogue</a>
 
                 @if(Auth::check())
                     <div class="relative group">

--- a/VirtueVerse/resources/views/book-editions/catalogue.blade.php
+++ b/VirtueVerse/resources/views/book-editions/catalogue.blade.php
@@ -4,33 +4,25 @@
 
 <head>
     @vite('resources/css/app.css')
-    @vite('resources/js/authors/author.js')
+    @vite('resources/js/bookEditions/bookEditionCatalogue.js')
+    @vite('resources/js/components/dataControl/filterControl.js')
     @vite('resources/js/shared/regexHelper.js')
 </head>
 
-    <h1 class="text-3xl font-semibold mb-6">{{ $bookTitle }}: catalogue</h1>
-    
-    <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
-        @foreach ($bookEditions as $bookEdition)
-        <a href="{{ route('book-edition.show', $bookEdition->id) }}" class="block bg-white rounded-lg shadow-md cursor-pointer">
-            <img src="{{ asset('book-template.png') }}" alt="{{ $bookEdition->title }}" class="w-full h-48 object-cover rounded-t-lg" />
-            <div class="p-4">
-                <h2 class="text-lg font-semibold mb-2">{{ $bookEdition->title }}</h2>
-                <p class="text-gray-600">Publicated on: {{ $bookEdition->publication_year }}</p>
-                @if ($bookEdition->isbn) 
-                <p class="text-gray-600">ISBN number: {{ $bookEdition->isbn }}</p>
-                @endif
-                <p class="text-gray-600">Total pages: {{ $bookEdition->pages }}</p>
-            </div>
-            <div class="p-4 border-t border-gray-300">
-                @php
-                $createdDate = \Carbon\Carbon::parse($bookEdition->created_at);
-                @endphp
+    <h1 class="text-3xl font-semibold mb-6" id="book-display-name">Book edition catalogue: {{ $bookTitle }}</h1>
 
-                <p class="text-gray-400 text-sm italic">Created on: {{ $createdDate->format('d-m-Y') }}</p>
-            </div>
-        </a>
+    <div class="edition-catalogue-filters flex space-x-5">
+        <x-data-control.filter-control name="book-filter" label="Book" model="book"></x-components.data-control.filter-control>
+        <x-data-control.filter-control name="author-filter" label="Author" model="author"></x-components.data-control.filter-control>
+        <x-data-control.input-control id="book-edition-search" label="book edition" model="book-edition"></x-components.data-control.filter-control>
+    </div>
+    
+    <div id="book-editions" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+        @foreach ($bookEditions as $bookEdition)
+            <x-books.book-edition-card :bookEdition="$bookEdition" />
         @endforeach
     </div>
 
+    <input type="hidden" id="selected-book-id" value="{{ $bookId }}" />
+    <input type="hidden" contenteditable="true" id="filter-listener" />
 @endsection

--- a/VirtueVerse/resources/views/components/books/book-edition-card.blade.php
+++ b/VirtueVerse/resources/views/components/books/book-edition-card.blade.php
@@ -1,0 +1,18 @@
+<a href="{{ route('book-edition.show', $bookEdition->id) }}" class="book-edition-card block bg-white rounded-lg shadow-md cursor-pointer">
+    <img src="{{ asset('book-template.png') }}" alt="{{ $bookEdition->title }}" class="w-full h-48 object-cover rounded-t-lg" />
+    <div class="p-4">
+        <h2 class="text-lg font-semibold mb-2">{{ $bookEdition->title }}</h2>
+        <p class="text-gray-600">Publicated on: {{ $bookEdition->publication_year }}</p>
+        @if ($bookEdition->isbn) 
+        <p class="text-gray-600">ISBN number: {{ $bookEdition->isbn }}</p>
+        @endif
+        <p class="text-gray-600">Total pages: {{ $bookEdition->pages }}</p>
+    </div>
+    <div class="p-4 border-t border-gray-300">
+        @php
+        $createdDate = \Carbon\Carbon::parse($bookEdition->created_at);
+        @endphp
+
+        <p class="text-gray-400 text-sm italic">Created on: {{ $createdDate->format('d-m-Y') }}</p>
+    </div>
+</a>

--- a/VirtueVerse/resources/views/components/data-control/filter-control.blade.php
+++ b/VirtueVerse/resources/views/components/data-control/filter-control.blade.php
@@ -1,0 +1,11 @@
+<div class="mb-4">
+    <select
+        class="block appearance-none w-full rounded text-red-700 leading-tight focus:outline-none focus:shadow-outline selectize"
+        id="{{ $name }}"
+        name="{{ $name }}"
+        model="{{ $model }}"
+        required
+    >
+        <option value="" selected>All {{ strtolower($label) }}s </option>
+    </select>
+</div>

--- a/VirtueVerse/resources/views/components/data-control/input-control.blade.php
+++ b/VirtueVerse/resources/views/components/data-control/input-control.blade.php
@@ -1,0 +1,3 @@
+<div class="mb-4">
+    <input placeholder="Search for a {{ $label }}" type="text" id="{{ $id }}" model="{{ $model }}" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline">
+</div>

--- a/VirtueVerse/routes/web.php
+++ b/VirtueVerse/routes/web.php
@@ -84,16 +84,21 @@ Route::get('/book/search', [BookController::class, 'search'])->name('book.search
 Route::get('book/searchStoredBooks', [BookController::class, 'searchStoredBooks'])->name('book.searchStoredBooks');
 Route::get('book/getBookInfo', [BookController::class, 'getBookInfo'])->name('book.getBookInfo');
 Route::get('book/getBook', [BookController::class, 'getBook'])->name('book.getBook');
+Route::get('book/getBookFilterValues', [BookController::class, 'getBookFilterValues'])->name('book.getBookFilterValues');
 Route::get('/book/{id}', [BookController::class, 'show'])->name('book.show');
 Route::get('book/create', [BookController::class, 'create'])->name('book.create');
 
 Route::get('/author/search', [AuthorController::class, 'search'])->name('author.search');
 Route::get('author/getAuthorInfo', [AuthorController::class, 'getAuthorInfo'])->name('author.getAuthorInfo');
+Route::get('author/getAuthorFilterValues', [AuthorController::class, 'getAuthorFilterValues'])->name('author.getAuthorFilterValues');
 
 Route::get('/book-edition/search', [BookEditionController::class, 'search'])->name('book-edition.search');
 Route::get('/book-edition/getBookEditions', [BookEditionController::class, 'getBookEditions'])->name('book-edition.getBookEditions');
+Route::get('book-edition/catalogue', [BookEditionController::class, 'catalogue'])->name('book-edition.catalogue.all');
+Route::get('/book-edition/retrieveFilteredItems', [BookEditionController::class, 'retrieveFilteredItems'])->name('book-edition.retrieveFilteredItems');
 Route::get('/book-edition/{id}', [BookEditionController::class, 'show'])->name('book-edition.show');
 Route::get('book-edition/catalogue/{id}', [BookEditionController::class, 'catalogue'])->name('book-edition.catalogue');
+Route::get('/book-edition/getBookEditionById', [BookEditionController::class, 'getBookEditionById'])->name('book-edition.getBookEditionById');
 
 Route::get('/test-database', function () {
     try {


### PR DESCRIPTION
## Changelog

- Reworked book edition catalogue into a dynamic filterable list of book editions
- Reworked 'selected book' routing when navigating to book edition catalogue from book details
- Added seperate data control functionality for catalogue pages (components + JS)
- Added filter + search functionality for book edition catalogue
- Added extra navigation to book edition catalogue page
- Tweaked and improved 'where like' back-end functionality
- Reworked book edition cards into component

## Description
Reworked the book editions catalogue page into a dynamic filterable catalogue page. Previously you could only view the editions of a single book. Now it is possible to dynamically switch between a full list and a selected list, through filtering and search functionality.

When navigating from a book details page, filters are automatically set and the corresponding details are shown. Through a dynamic back-end method, the list is dynamically changed upon setting or removing a filter.

## Documentation
Added documentation on catalogue pages