### PR TITLE
Added functionality for retrieving Open Library covers

### DIFF
--- a/VirtueVerse/app/Http/Controllers/BookController.php
+++ b/VirtueVerse/app/Http/Controllers/BookController.php
@@ -300,6 +300,37 @@ class BookController extends Controller
     }
 
     /**
+     * Get book image from Open Library based on the Open Library identifier
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function getBookImage(Request $request)
+    {
+        $olid = $request->input('olid');
+
+        $response = Http::withOptions(['verify' => false])->get("https://covers.openlibrary.org/b/olid/$olid-L.jpg?default=false");
+
+        // If the API request returns a 404 response, serve the book template image
+        if ($response->status() == 404) {
+            return response()->file(public_path('book-template.png'));
+        }
+
+        if ($response->successful()) 
+        {
+            $imageData = $response->body();
+    
+            return response($imageData, 200)->header('Content-Type', 'image/jpeg');
+        }
+        else
+        {
+            $errorDetails = $response->json();
+            Log::error('API request failed: ' . json_encode($errorDetails));
+            return response()->json(['error' => "API request failed."], 500);
+        }
+    }
+
+    /**
      * Get book filter values for use in filtering.
      *
      * @param  \Illuminate\Http\Request  $request

--- a/VirtueVerse/app/Http/Controllers/BookEditionController.php
+++ b/VirtueVerse/app/Http/Controllers/BookEditionController.php
@@ -279,6 +279,37 @@ class BookEditionController extends Controller
     }
 
     /**
+     * Get book edition image from Open Library based on the Open Library identifier
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function getBookEditionImage(Request $request)
+    {
+        $isbn = $request->input('isbn');
+
+        $response = Http::withOptions(['verify' => false])->get("https://covers.openlibrary.org/b/isbn/$isbn-L.jpg?default=false");
+
+        // If the API request returns a 404 response, serve the book template image
+        if ($response->status() == 404) {
+            return response()->file(public_path('book-template.png'));
+        }
+
+        if ($response->successful()) 
+        {
+            $imageData = $response->body();
+    
+            return response($imageData, 200)->header('Content-Type', 'image/jpeg');
+        }
+        else
+        {
+            $errorDetails = $response->json();
+            Log::error('API request failed: ' . json_encode($errorDetails));
+            return response()->json(['error' => "API request failed."], 500);
+        }
+    }
+
+    /**
      * Get book edition by ID.
      *
      * @param  int  $id

--- a/VirtueVerse/app/View/Components/books/BookCard.php
+++ b/VirtueVerse/app/View/Components/books/BookCard.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\View\Components\books;
+
+use Closure;
+use Illuminate\View\Component;
+use Illuminate\Contracts\View\View;
+
+class BookCard extends Component
+{
+    public $book;
+
+    public function __construct($book)
+    {
+        $this->book = $book;
+    }
+
+    /**
+     * Get the view / contents that represent the component.
+     */
+    public function render(): View|Closure|string
+    {
+        return view('components.books.book-card');
+    }
+}

--- a/VirtueVerse/resources/js/books/book.js
+++ b/VirtueVerse/resources/js/books/book.js
@@ -82,7 +82,6 @@ async function displaySearchResults(results) {
 async function searchBooks(query) {
     try {
         query = spaceEncoder(query) // Replace space with a valid character
-        debugger;
         const response = await axios.get(`/book/search?query=${query}`);
 
         const results = response.data.results.docs;

--- a/VirtueVerse/resources/views/book-editions/show.blade.php
+++ b/VirtueVerse/resources/views/book-editions/show.blade.php
@@ -11,7 +11,7 @@
 <div class="flex justify-center mt-8">
 
     <div class="w-1/4">
-        <img src="{{ asset('book-template.png') }}" alt="Book Cover" class="w-full">
+        <img src="{{ route('book-edition.getBookEditionImage', ['isbn' => $bookEdition->isbn]) }}" alt="Book Edition cover" class="w-full">
         
         <div class="mt-4 flex flex-col space-y-4">
             @auth

--- a/VirtueVerse/resources/views/books/catalogue.blade.php
+++ b/VirtueVerse/resources/views/books/catalogue.blade.php
@@ -12,22 +12,7 @@
     
     <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
         @foreach ($books as $book)
-        <a href="/book/{{ $book->id }}" class="block bg-white rounded-lg shadow-md cursor-pointer">
-            <img src="{{ asset('book-template.png') }}" alt="{{ $book->title }}" class="w-full h-48 object-cover rounded-t-lg" />
-            <div class="p-4">
-                <h2 class="text-lg font-semibold mb-2">{{ $book->title }}</h2>
-                <p class="text-gray-600">{{ $book->author->name }}</p>
-                <p class="text-gray-400 italic mb-4">Original publication: {{ $book->publication_year }}</p>
-                <p class="text-gray-700">{{ Str::limit($book->description, 150) }}</p>
-            </div>
-            <div class="p-4 border-t border-gray-300">
-                @php
-                $createdDate = \Carbon\Carbon::parse($book->created_at);
-                @endphp
-
-                <p class="text-gray-400 text-sm italic">Created on: {{ $createdDate->format('d-m-Y') }}</p>
-            </div>
-        </a>
+            <x-books.book-card :book="$book" />
         @endforeach
     </div>
 

--- a/VirtueVerse/resources/views/books/show.blade.php
+++ b/VirtueVerse/resources/views/books/show.blade.php
@@ -12,7 +12,7 @@
 
     <!-- Book image and actions -->
     <div class="w-1/4">
-        <img src="{{ asset('book-template.png') }}" alt="Book Cover" class="w-full">
+        <img src="{{ route('book.getBookImage', ['olid' => $book->editions_key]) }}" alt="Book Cover" class="w-full">
         
         <div class="mt-4 flex flex-col space-y-4">
             @if ($book->editions->isNotEmpty())

--- a/VirtueVerse/resources/views/components/books/book-card.blade.php
+++ b/VirtueVerse/resources/views/components/books/book-card.blade.php
@@ -1,0 +1,16 @@
+<a href="/book/{{ $book->id }}" class="block bg-white rounded-lg shadow-md cursor-pointer">
+    <img src="{{ asset('book-template.png') }}" alt="{{ $book->title }}" class="w-full h-48 object-cover rounded-t-lg" />
+    <div class="p-4">
+        <h2 class="text-lg font-semibold mb-2">{{ $book->title }}</h2>
+        <p class="text-gray-600">{{ $book->author->name }}</p>
+        <p class="text-gray-400 italic mb-4">Original publication: {{ $book->publication_year }}</p>
+        <p class="text-gray-700">{{ Str::limit($book->description, 150) }}</p>
+    </div>
+    <div class="p-4 border-t border-gray-300">
+        @php
+        $createdDate = \Carbon\Carbon::parse($book->created_at);
+        @endphp
+
+        <p class="text-gray-400 text-sm italic">Created on: {{ $createdDate->format('d-m-Y') }}</p>
+    </div>
+</a>

--- a/VirtueVerse/resources/views/components/books/book-edition-card.blade.php
+++ b/VirtueVerse/resources/views/components/books/book-edition-card.blade.php
@@ -1,5 +1,5 @@
 <a href="{{ route('book-edition.show', $bookEdition->id) }}" class="book-edition-card block bg-white rounded-lg shadow-md cursor-pointer">
-    <img src="{{ asset('book-template.png') }}" alt="{{ $bookEdition->title }}" class="w-full h-48 object-cover rounded-t-lg" />
+    <img src="{{ route('book-edition.getBookEditionImage', ['isbn' => $bookEdition->isbn]) }}" alt="{{ $bookEdition->title }}" class="w-full h-48 object-cover rounded-t-lg" />
     <div class="p-4">
         <h2 class="text-lg font-semibold mb-2">{{ $bookEdition->title }}</h2>
         <p class="text-gray-600">Publicated on: {{ $bookEdition->publication_year }}</p>

--- a/VirtueVerse/routes/web.php
+++ b/VirtueVerse/routes/web.php
@@ -83,6 +83,7 @@ Route::get('book/catalogue', [BookController::class, 'catalogue'])->name('book.c
 Route::get('/book/search', [BookController::class, 'search'])->name('book.search');
 Route::get('book/searchStoredBooks', [BookController::class, 'searchStoredBooks'])->name('book.searchStoredBooks');
 Route::get('book/getBookInfo', [BookController::class, 'getBookInfo'])->name('book.getBookInfo');
+Route::get('book/getBookImage', [BookController::class, 'getBookImage'])->name('book.getBookImage');
 Route::get('book/getBook', [BookController::class, 'getBook'])->name('book.getBook');
 Route::get('book/getBookFilterValues', [BookController::class, 'getBookFilterValues'])->name('book.getBookFilterValues');
 Route::get('/book/{id}', [BookController::class, 'show'])->name('book.show');
@@ -92,6 +93,7 @@ Route::get('/author/search', [AuthorController::class, 'search'])->name('author.
 Route::get('author/getAuthorInfo', [AuthorController::class, 'getAuthorInfo'])->name('author.getAuthorInfo');
 Route::get('author/getAuthorFilterValues', [AuthorController::class, 'getAuthorFilterValues'])->name('author.getAuthorFilterValues');
 
+Route::get('/book-edition/getBookEditionImage', [BookEditionController::class, 'getBookEditionImage'])->name('book-edition.getBookEditionImage');
 Route::get('/book-edition/search', [BookEditionController::class, 'search'])->name('book-edition.search');
 Route::get('/book-edition/getBookEditions', [BookEditionController::class, 'getBookEditions'])->name('book-edition.getBookEditions');
 Route::get('book-edition/catalogue', [BookEditionController::class, 'catalogue'])->name('book-edition.catalogue.all');


### PR DESCRIPTION
## Changelog
- Added functionality for dynamically retrieving book and book edition covers
- Added covers on detail pages
- Added covers on catalogue pages
- Improved functionality for loading book catalogue items

## Description
Added functionality to retrieve book and book edition covers in case the given items are linked using Open Library. This is done by using the respective open library key and book edition keys. Because there is not yet an author details / catalogue page implemented, this functionality has not yet been added for the authors model.

There are some limitations to this functionality:
- Firstly, because a seperate request is made for each item, the catalogue can become quite slow. A better implementation may be necessary in the future
- Secondly, because of the catalogue filtering functionality which is not dynamically done using blade or Livewire, book editions will use the book template image upon applying filters

## Documentation
None