### PR TITLE
Improved navigation to study trajectories

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ Through added user roles, extra authorization is added to the application. Admin
 #### Description
 Study trajectories create the possibility for a user to use tools for support when studying a book. Through creating a book and book edition inside of VirtueVerse, users can start their own study trajectories for this given edition. Through this, users can set goals, retrieve automated to-do tasks for the given book and track their progress in certain tasks.
 
+#### Viewing trajectories
+Trajectories can be viewed by navigating to the profile page of your account. Here you can find a button for the study trajectory catalogue, which will display all your created study trajectories. This page is also accessible through the footer once logged in
+
 ## Authorization
 
 ### Description

--- a/VirtueVerse/app/Http/Controllers/StudyTrajectoryController.php
+++ b/VirtueVerse/app/Http/Controllers/StudyTrajectoryController.php
@@ -36,6 +36,18 @@ class StudyTrajectoryController extends Controller
     }
 
     /**
+     * Display a listing of all owned study trajectories.
+     *
+     * @return \Illuminate\View\View
+     */
+    public function catalogue($userId)
+    {
+        $studyTrajectories = StudyTrajectory::where('created_by', $userId)->get();
+
+        return view('study-trajectories.catalogue', ['studyTrajectories' => $studyTrajectories]);
+    }
+
+    /**
      * Store a newly created study trajectory in storage.
      *
      * @param  \Illuminate\Http\Request  $request

--- a/VirtueVerse/app/View/Components/study-trajectories/StudyTrajectoryCard.php
+++ b/VirtueVerse/app/View/Components/study-trajectories/StudyTrajectoryCard.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\View\Components\StudyTrajectories;
+
+use Closure;
+use Illuminate\View\Component;
+use Illuminate\Contracts\View\View;
+
+class StudyTrajectoryCard extends Component
+{
+    public $studyTrajectory;
+
+    public function __construct($studyTrajectory)
+    {
+        $this->studyTrajectory = $studyTrajectory;
+    }
+
+    /**
+     * Get the view / contents that represent the component.
+     */
+    public function render(): View|Closure|string
+    {
+        return view('components.study-trajectories.study-trajectory-card');
+    }
+}

--- a/VirtueVerse/resources/views/app.blade.php
+++ b/VirtueVerse/resources/views/app.blade.php
@@ -108,13 +108,20 @@
                             @auth
                                 <ul class="text-sm">
                                     <li><a href="{{ route('profile.edit') }}" class="hover:underline">My Profile</a></li>
+                                    <li><a href="{{ route('study-trajectory.catalogue', Auth::user()->id) }}" class="hover:underline">My trajectories</a></li>                             
                                 </ul>
                             @endauth
                         </div>
                     </div>
                 </div>
                 <div class="footer-right w-full lg:w-1/5">
-                    <p class="text-sm text-center lg:text-right">© VirtueVerse. All Rights Reserved.</p>
+                    <p class="text-sm text-center lg:text-left">
+                        © VirtueVerse. All Rights Reserved.
+                    </p>
+                    <p class="text-sm text-center lg:text-left">
+                        Functionality made possible by
+                        <a href="https://openlibrary.org/" target="_blank" rel="noopener noreferrer" class="text-blue-500 hover:underline">Open Library</a>
+                    </p>
                 </div>
             </div>
         </footer>

--- a/VirtueVerse/resources/views/components/books/book-card.blade.php
+++ b/VirtueVerse/resources/views/components/books/book-card.blade.php
@@ -1,16 +1,16 @@
-<a href="/book/{{ $book->id }}" class="block bg-white rounded-lg shadow-md cursor-pointer">
-    <img src="{{ asset('book-template.png') }}" alt="{{ $book->title }}" class="w-full h-48 object-cover rounded-t-lg" />
-    <div class="p-4">
-        <h2 class="text-lg font-semibold mb-2">{{ $book->title }}</h2>
-        <p class="text-gray-600">{{ $book->author->name }}</p>
-        <p class="text-gray-400 italic mb-4">Original publication: {{ $book->publication_year }}</p>
-        <p class="text-gray-700">{{ Str::limit($book->description, 150) }}</p>
-    </div>
-    <div class="p-4 border-t border-gray-300">
-        @php
-        $createdDate = \Carbon\Carbon::parse($book->created_at);
-        @endphp
+        <a href="/book/{{ $book->id }}" class="block bg-white rounded-lg shadow-md cursor-pointer">
+            <img src="{{ asset('book-template.png') }}" alt="{{ $book->title }}" class="w-full h-48 object-cover rounded-t-lg" />
+            <div class="p-4">
+                <h2 class="text-lg font-semibold mb-2">{{ $book->title }}</h2>
+                <p class="text-gray-600">{{ $book->author->name }}</p>
+                <p class="text-gray-400 italic mb-4">Original publication: {{ $book->publication_year }}</p>
+                <p class="text-gray-700">{{ Str::limit($book->description, 150) }}</p>
+            </div>
+            <div class="p-4 border-t border-gray-300">
+                @php
+                $createdDate = \Carbon\Carbon::parse($book->created_at);
+                @endphp
 
-        <p class="text-gray-400 text-sm italic">Created on: {{ $createdDate->format('d-m-Y') }}</p>
-    </div>
-</a>
+                <p class="text-gray-400 text-sm italic">Created on: {{ $createdDate->format('d-m-Y') }}</p>
+            </div>
+        </a>

--- a/VirtueVerse/resources/views/components/primary-button.blade.php
+++ b/VirtueVerse/resources/views/components/primary-button.blade.php
@@ -1,3 +1,7 @@
 <button {{ $attributes->merge(['type' => 'submit', 'class' => 'inline-flex items-center px-4 py-2 bg-gray-800 dark:bg-gray-200 border border-transparent rounded-md font-semibold text-xs text-white dark:text-gray-800 uppercase tracking-widest hover:bg-gray-700 dark:hover:bg-white focus:bg-gray-700 dark:focus:bg-white active:bg-gray-900 dark:active:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition ease-in-out duration-150']) }}>
-    {{ $slot }}
+    @if(isset($href))
+        <a href="{{ $href }}">{{ $slot }}</a>
+    @else
+        {{ $slot }}
+    @endif
 </button>

--- a/VirtueVerse/resources/views/components/study-trajectories/study-trajectory-card.blade.php
+++ b/VirtueVerse/resources/views/components/study-trajectories/study-trajectory-card.blade.php
@@ -1,0 +1,12 @@
+<a href="{{ route('study-trajectory.show', $studyTrajectory->id) }}" class="block bg-white rounded-lg shadow-md cursor-pointer">
+    <div class="p-4">
+        <h2 class="text-lg font-semibold mb-2">{{ $studyTrajectory->title }}</h2>
+        <p class="text-gray-700 mb-4">{{ Str::limit($studyTrajectory->description, 150) }}</p>
+        <span class="text-sm py-1 px-2 rounded-full {{ $studyTrajectory->active ? 'bg-green-500 text-white' : 'bg-red-500 text-white' }}">
+            {{ $studyTrajectory->active ? 'Active' : 'Paused' }}
+        </span>
+    </div>
+    <div class="p-4 border-t border-gray-300">
+        <p class="text-gray-400 text-sm italic">Created on: {{ $studyTrajectory->created_at->format('d-m-Y') }}</p>
+    </div>
+</a>

--- a/VirtueVerse/resources/views/profile/edit.blade.php
+++ b/VirtueVerse/resources/views/profile/edit.blade.php
@@ -12,6 +12,24 @@
                     @include('profile.partials.update-profile-information-form')
                 </div>
             </div>
+            
+            <div class="p-4 sm:p-8 bg-white dark:bg-gray-800 shadow sm:rounded-lg">
+                <div class="max-w-xl">
+                    <section>
+                        <header class="space-y-6">
+                            <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100">
+                                Study trajectories
+                            </h2>
+                    
+                            <div class="flex items-center gap-4">
+                                <x-primary-button href="{{ route('study-trajectory.catalogue', $user->id) }}">
+                                    {{ __('View my study trajectories') }}
+                                </x-primary-button>
+                            </div>
+                        </header>
+                    </section>
+                </div>
+            </div>
 
             <div class="p-4 sm:p-8 bg-white dark:bg-gray-800 shadow sm:rounded-lg">
                 <div class="max-w-xl">

--- a/VirtueVerse/resources/views/study-trajectories/catalogue.blade.php
+++ b/VirtueVerse/resources/views/study-trajectories/catalogue.blade.php
@@ -1,0 +1,18 @@
+@extends('app')
+
+@section('content')
+
+<head>
+    @vite('resources/css/app.css')
+    @vite('resources/js/shared/regexHelper.js')
+</head>
+
+    <h1 class="text-3xl font-semibold mb-6">Study Trajectory catalogue</h1>
+    
+    <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+        @foreach ($studyTrajectories as $studyTrajectory)
+            <x-study-trajectories.study-trajectory-card :studyTrajectory="$studyTrajectory" />
+        @endforeach
+    </div>
+
+@endsection

--- a/VirtueVerse/routes/web.php
+++ b/VirtueVerse/routes/web.php
@@ -52,6 +52,7 @@ Route::middleware(['auth', 'can.edit.record'])->group(function () {
     Route::put('book/{id}', [BookController::class, 'update'])->name('book.update');
     Route::get('book-edition/edit/{id}', [BookEditionController::class, 'edit'])->name('book-edition.edit');
     Route::put('book-edition/{id}', [BookEditionController::class, 'update'])->name('book-edition.update');
+    Route::get('study-trajectory/catalogue/{id}', [StudyTrajectoryController::class, 'catalogue'])->name('study-trajectory.catalogue');
     Route::get('/study-trajectory/{id}', [StudyTrajectoryController::class, 'show'])->name('study-trajectory.show');
     Route::put('/study-trajectory/{id}/{active}', [StudyTrajectoryController::class, 'changeTrajectoryStatus'])->name('study-trajectory.changeTrajectoryStatus');
 });


### PR DESCRIPTION
## Changelog
- Added study trajectory catalogue page
- Made navigation to study trajectories possible from profile page
- Improved footer elements

## Description
By navigating to the user profile (once logged in), you can now view your own created study trajectories. Similar to the book and book edition pages, this reference will bring you to a catalogue page with your created study trajectories. From here on you can view the details of a given trajectory

## Documentation
Improved the README with information on study trajectory navigation