### PR TITLE
Added functionality for creating study entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ Study trajectories create the possibility for a user to use tools for support wh
 #### Viewing trajectories
 Trajectories can be viewed by navigating to the profile page of your account. Here you can find a button for the study trajectory catalogue, which will display all your created study trajectories. This page is also accessible through the footer once logged in
 
+### Study entries
+
+#### Description
+Through study trajectories, a user can create study entries for the book edition he's created study trajectory for. Through study entries, it's possible to give information on the studying progress of a book (read pages, spent minutes, notes, glossaries etc.). Through this data, it's possible to gain insights provided by VirtueVerse.
+
 ## Authorization
 
 ### Description

--- a/VirtueVerse/app/Http/Controllers/StudyEntryController.php
+++ b/VirtueVerse/app/Http/Controllers/StudyEntryController.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\StudyEntry;
+use App\Models\PagesEntry;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class StudyEntryController extends Controller
+{
+    public function create($study_trajectory_id)
+    {
+        return view('study-entries.create', compact('study_trajectory_id'));
+    }
+
+    public function store(Request $request)
+    {
+        $validatedData = $request->validate([
+            'date' => 'required|date',
+            'read-pages' => 'required|integer',
+            'notes' => 'nullable|string',
+            'study-trajectory-id' => 'required|exists:study_trajectories,id', // Ensure the ID exists in the study_trajectories table
+        ]);
+    
+        // Create a new StudyEntry
+        $studyEntry = new StudyEntry();
+        $studyEntry->study_trajectory_id = $validatedData['study-trajectory-id'];
+        $studyEntry->save();
+    
+        // Create a new PagesEntry associated with the StudyEntry
+        $pagesEntry = new PagesEntry();
+        $pagesEntry->study_entry_id = $studyEntry->id; // Link it to the newly created StudyEntry
+        $pagesEntry->read_pages = $validatedData['read-pages'];
+        $pagesEntry->date = $validatedData['date'];
+        $pagesEntry->notes = $validatedData['notes'];
+        $pagesEntry->save();
+
+        // $book = Book::create([
+        //     'title' => $request->input('title'),
+        //     'author' => $request->input('author'),
+        //     'publication_year' => $request->input('publication-year'),
+        //     'description' => $request->input('description'),
+        //     'open_library_key' => $request->input('open-library-key'),
+        //     'editions_key' => $editionsKey,
+        //     'author_id' => $request->input('author-id')
+        // ]);
+    
+        return redirect()->route('study-trajectory.show', ['id' => $validatedData['study-trajectory-id']])->with('success', 'Study entry created successfully.');
+    }
+}

--- a/VirtueVerse/app/Models/PagesEntry.php
+++ b/VirtueVerse/app/Models/PagesEntry.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Models;
+
+use App\Observers\PagesEntryObserver;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class PagesEntry extends Model
+{
+    protected $table = "pages_entries";
+
+    protected $fillable = [
+        'study_entry_id',
+        'read_pages',
+        'notes',
+        'date'
+    ];
+    
+    /**
+     * The "booting" method of the model.
+     *
+     * This method is called when the model is bootstrapped, and it registers the PagesEntryObserver.
+     *
+     * @return void
+     */
+    protected static function boot()
+    {
+        parent::boot();
+    
+        PagesEntry::observe(PagesEntryObserver::class);
+    }
+
+    /**
+     * Define a many-to-one relationship with the StudyEntry model.
+     *
+     * This method defines a relationship where a pages entry belongs to a single study entry.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function studyEntry() 
+    {
+        return $this->belongsTo(StudyEntry::class, 'study_entry_id');
+    }
+
+    use HasFactory;
+}

--- a/VirtueVerse/app/Models/StudyEntry.php
+++ b/VirtueVerse/app/Models/StudyEntry.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Models;
+
+use App\Observers\StudyEntryObserver;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class StudyEntry extends Model
+{
+    protected $table = "study_entries";
+
+    protected $fillable = [
+        'study_trajectory_id',
+    ];
+    
+    /**
+     * The "booting" method of the model.
+     *
+     * This method is called when the model is bootstrapped, and it registers the StudyEntryObserver.
+     *
+     * @return void
+     */
+    protected static function boot()
+    {
+        parent::boot();
+    
+        StudyEntry::observe(StudyEntryObserver::class);
+    }
+
+    /**
+     * Define a many-to-one relationship with the StudyTrajectory model.
+     *
+     * This method defines a relationship where a study entry belongs to a single study trajectory.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function studyTrajectory() 
+    {
+        return $this->belongsTo(StudyTrajectory::class, 'study_trajectory_id');
+    }
+
+    public function pagesEntry()
+    {
+        return $this->hasOne(PagesEntry::class, 'study_entry_id');
+    }
+
+    use HasFactory;
+}

--- a/VirtueVerse/app/Observers/PagesEntryObserver.php
+++ b/VirtueVerse/app/Observers/PagesEntryObserver.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Observers;
+use App\Models\PagesEntry;
+
+class PagesEntryObserver
+{
+    /**
+     * Handle the "creating" event for the Pages Entry model.
+     *
+     * This method is called when a new pages entry is being created.
+     * It assigns the ID of the authenticated user (if available) to the "created_by" attribute of the pages entry.
+     *
+     * @param  PagesEntry  $pagesEntry
+     * @return void
+     */
+    public function creating(PagesEntry $pagesEntry)
+    {
+        $pagesEntry->created_by = auth()->id();
+    }
+}

--- a/VirtueVerse/app/Observers/StudyEntryObserver.php
+++ b/VirtueVerse/app/Observers/StudyEntryObserver.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Observers;
+use App\Models\StudyEntry;
+
+class StudyEntryObserver
+{
+    /**
+     * Handle the "creating" event for the Study Entry model.
+     *
+     * This method is called when a new study entry is being created.
+     * It assigns the ID of the authenticated user (if available) to the "created_by" attribute of the study entry.
+     *
+     * @param  StudyEntry $studyEntry
+     * @return void
+     */
+    public function creating(StudyEntry $studyEntry)
+    {
+        $studyEntry->created_by = auth()->id();
+    }
+}

--- a/VirtueVerse/app/Providers/EventServiceProvider.php
+++ b/VirtueVerse/app/Providers/EventServiceProvider.php
@@ -6,6 +6,8 @@ use App\Models\Book;
 use App\Models\BookEdition;
 use App\Observers\BookEditionObserver;
 use App\Observers\BookObserver;
+use App\Observers\PagesEntryObserver;
+use App\Observers\StudyEntryObserver;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
@@ -33,6 +35,12 @@ class EventServiceProvider extends ServiceProvider
         ],
         BookCreating::class => [
             BookObserver::class,
+        ],
+        StudyEntryCreating::class => [
+            StudyEntryObserver::class,
+        ],
+        PagesEntryCreating::class => [
+            PagesEntryObserver::class,
         ],
     ];
 

--- a/VirtueVerse/database/migrations/2023_10_25_135657_create_study_entry_table.php
+++ b/VirtueVerse/database/migrations/2023_10_25_135657_create_study_entry_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('study_entries', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('study_trajectory_id');
+            $table->foreign('study_trajectory_id')->references('id')->on('study_trajectories');
+            $table->unsignedBigInteger('created_by')->nullable();
+            $table->foreign('created_by')->references('id')->on('users');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('study_entries');
+    }
+};

--- a/VirtueVerse/database/migrations/2023_10_25_140024_create_pages_entries_table.php
+++ b/VirtueVerse/database/migrations/2023_10_25_140024_create_pages_entries_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('pages_entries', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('study_entry_id');
+            $table->foreign('study_entry_id')->references('id')->on('study_entries');
+            $table->integer('read_pages');
+            $table->text('notes')->nullable();
+            $table->date('date');
+            $table->unsignedBigInteger('created_by')->nullable();
+            $table->foreign('created_by')->references('id')->on('users');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('pages_entries');
+    }
+};

--- a/VirtueVerse/resources/views/study-entries/create.blade.php
+++ b/VirtueVerse/resources/views/study-entries/create.blade.php
@@ -1,0 +1,39 @@
+@extends('app')
+
+@section('content')
+<head>
+    @vite('resources/css/app.css')
+    @vite('resources/js/app.js')
+    @vite('resources/js/shared/regexHelper.js')
+</head>
+
+<h1 class="text-3xl font-bold underline">Create study entry</h1>
+
+<!-- Study entry Creation Form -->
+<form action="{{ route('study-entry.store') }}" method="POST" class="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4">
+    @csrf
+
+    @if ($errors->any())
+        <x-forms.validation-errors :errors="$errors" />
+    @endif
+
+    {{-- study_trajectory_id --}}
+    {{-- read_pages --}}
+    {{-- notes --}}
+    {{-- date --}}
+    <x-forms.text-input type="date" id="date" label="Reading date" name="date" placeholder="Reading date" value="{{ old('date') }}" />
+    <x-forms.text-input type="number" id="read-pages" label="Read pages" name="read-pages" placeholder="Read pages" value="{{ old('read-pages') }}" /> 
+    <x-forms.text-input type="text" id="notes" label="Notes" name="notes" placeholder="Notes" value="{{ old('notes') }}" />
+
+    <input type="hidden" name="study-trajectory-id" id="study-trajectory-id" value="{{ $study_trajectory_id }}">
+
+    <div class="flex items-center justify-between">
+        <button
+            class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline"
+            type="submit">
+            Add study entry
+        </button>
+    </div>
+</form>
+
+@endsection

--- a/VirtueVerse/resources/views/study-trajectories/show.blade.php
+++ b/VirtueVerse/resources/views/study-trajectories/show.blade.php
@@ -17,20 +17,21 @@
         <div class="mt-4 flex flex-col space-y-4">
             @if($studyTrajectory->created_by === Auth::user()->id)
                 @if ($studyTrajectory->active)
-                    <form method="POST" action="{{ route('study-trajectory.changeTrajectoryStatus', ['id' => $studyTrajectory->id, 'active' => 0]) }}">
+                    <form class="w-full" method="POST" action="{{ route('study-trajectory.changeTrajectoryStatus', ['id' => $studyTrajectory->id, 'active' => 0]) }}">
                         @csrf
                         @method('PUT')
-                        <button class="bg-red-500 hover:bg-red-700 text-white font-medium py-2 px-4 rounded-lg">Pause Trajectory</button>
+                        <button class="w-full bg-red-500 hover:bg-red-700 text-white font-medium py-2 px-4 rounded-lg">Pause Trajectory</button>
                     </form>
                 @else
-                    <form method="POST" action="{{ route('study-trajectory.changeTrajectoryStatus', ['id' => $studyTrajectory->id, 'active' => 1]) }}">
+                    <form class="w-full" method="POST" action="{{ route('study-trajectory.changeTrajectoryStatus', ['id' => $studyTrajectory->id, 'active' => 1]) }}">
                         @csrf
                         @method('PUT')
-                        <button class="bg-green-500 hover-bg-green-700 text-white font-medium py-2 px-4 rounded-lg">Resume Trajectory</button>
+                        <button class="w-full bg-green-500 hover-bg-green-700 text-white font-medium py-2 px-4 rounded-lg">Resume Trajectory</button>
                     </form>
                 @endif
             @endif
 
+            <a href="{{ route('study-entry.create', $studyTrajectory->id) }}" class="text-center bg-blue-500 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded-lg">Add study entry</a>
         </div>
     </div>
 

--- a/VirtueVerse/routes/web.php
+++ b/VirtueVerse/routes/web.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Auth\RegisteredUserController;
 use App\Http\Controllers\BookEditionController;
+use App\Http\Controllers\StudyEntryController;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\DB;
 use App\Http\Controllers\BookController;
@@ -74,6 +75,9 @@ Route::middleware(['auth', 'auth.roles:Admin,Editor,User'])->group(function () {
     // Book edition routes
     Route::get('book-edition/create', [BookEditionController::class, 'create'])->name('book-edition.create');
     Route::post('book-edition/store', [BookEditionController::class, 'store'])->name('book-edition.store')->middleware('web');
+
+    Route::get('study-entry/create/{study_trajectory_id}', [StudyEntryController::class, 'create'])->name('study-entry.create');
+    Route::post('study-entry/store', [StudyEntryController::class,'store'])->name('study-entry.store')->middleware('web');
 });
 
 


### PR DESCRIPTION
## Changelog
- Added functonality for adding study entries on study trajectories
- Added read pages as a way to enter a study entry
- Added authentication, observers etc. for both tables

## Description
With this pull request it is made possible to create a study entry for your owned study trajectory. Through the ability to give an indication of the amount of read pages on a given date, it will be made possible to create and track insights on progress studying a book edition.

## Documentation
Added Study Entry information to README